### PR TITLE
(#25) && (#26)

### DIFF
--- a/api.go
+++ b/api.go
@@ -14,8 +14,13 @@ type merriamAPI []struct {
 }
 
 func (API merriamAPI) getDef() []string {
-	defer recovery("invalid")
-	return API[0].Shortdef
+	defer recovery("empty")
+
+	if len(API) > 0 {
+		return API[0].Shortdef
+	}
+
+	return []string(nil)
 }
 
 func (API merriamAPI) marshallAPI(APIType string, bodyBytes []byte) merriamAPI {
@@ -42,6 +47,7 @@ type googleAPI []struct {
 
 // TODO(#27): does not properly handle nested definitions for unGoogleAPI
 func (API googleAPI) getDef() []string {
+	defer recovery("empty")
 
 	if len(API) > 0 {
 		definitions := make([]string, len(API[0].Meanings))
@@ -50,6 +56,7 @@ func (API googleAPI) getDef() []string {
 		}
 		return definitions
 	}
+
 	return []string(nil)
 }
 

--- a/dictionary.go
+++ b/dictionary.go
@@ -7,7 +7,7 @@ import (
 
 func updateDict(dictionary map[string][]string, word string, definition []string) bool {
 	// TODO(#25): not working for all instances of nil definitions
-	if definition != nil {
+	if len(definition) > 0 {
 		dictionary[word] = definition
 		return false
 	}

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func procWord(word string, verbosity int) {
 		err := updateDict(dictionary, word, definition)
 		// TODO(#26): This might be redudant, double check isntances where this occurs over 'defer recovery'
 		if err != false {
-			fmt.Printf("\"%v\" - not in dictionary - %v\n", word, dictionary)
+			fmt.Printf("\"%v\" - Not found \n", word)
 		} else {
 			storeJSON(defPath+"/"+dictFile, dictionary)
 			displayDef(definition, 0)

--- a/requests.go
+++ b/requests.go
@@ -13,7 +13,7 @@ func recovery(errType string) {
 	if r := recover(); r != nil {
 		switch errType {
 		case "invalid":
-			fmt.Println("not in database")
+			return
 		}
 	}
 }


### PR DESCRIPTION
(#25) Re implement handling of empty responses with defer and recovery
(#26) Switch to more user friendly output when words are not found